### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 An MCP server implementation that provides screenshot functionality using Puppeteer. This server allows capturing screenshots of web pages and local HTML files through a simple MCP tool interface.
 
+<a href="https://glama.ai/mcp/servers/@sethbang/mcp-screenshot-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@sethbang/mcp-screenshot-server/badge" alt="Screenshot Server MCP server" />
+</a>
+
 ## Features
 
 - Capture screenshots of any web page or local HTML file


### PR DESCRIPTION
This PR adds a badge for the [MCP Screenshot Server](https://glama.ai/mcp/servers/@sethbang/mcp-screenshot-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@sethbang/mcp-screenshot-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@sethbang/mcp-screenshot-server/badge" alt="Screenshot Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.