### PR TITLE
Change default output directory to ~/Documents/screenshots

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -18,8 +18,17 @@ export const MAX_CONCURRENT_SCREENSHOTS = 3;
  */
 export const homeDir = process.env.HOME || '/tmp';
 
+/**
+ * Resolved default output directory for screenshots.
+ * Priority: 1) SCREENSHOT_OUTPUT_DIR env var  2) ~/Documents/screenshots  3) ~/Desktop/Screenshots
+ */
+export const configuredOutDir = process.env.SCREENSHOT_OUTPUT_DIR
+  ? join(homeDir, process.env.SCREENSHOT_OUTPUT_DIR.replace(/^~\/?/, ''))
+  : join(homeDir, 'Documents', 'screenshots');
+
 export const ALLOWED_OUTPUT_DIRS: readonly string[] = [
-  join(homeDir, 'Desktop', 'Screenshots'), // ~/Desktop/Screenshots (default output)
+  join(homeDir, 'Desktop', 'Screenshots'), // ~/Desktop/Screenshots (original default)
+  configuredOutDir,                         // Configured default output directory
   '/tmp',                                   // System temp directory
   join(homeDir, 'Downloads'),               // ~/Downloads
   join(homeDir, 'Documents'),               // ~/Documents

--- a/src/config/runtime.ts
+++ b/src/config/runtime.ts
@@ -1,11 +1,16 @@
 
 import { Semaphore } from '../utils/semaphore.js';
-import { MAX_CONCURRENT_SCREENSHOTS, homeDir } from './index.js';
+import { MAX_CONCURRENT_SCREENSHOTS, homeDir, configuredOutDir } from './index.js';
 import { mkdirSync } from 'fs';
-import { join } from 'path';
 
 export { homeDir };
-export const defaultOutDir = join(homeDir, 'Documents', 'screenshots');
+
+/**
+ * Default output directory for screenshots.
+ * Configurable via SCREENSHOT_OUTPUT_DIR environment variable.
+ * Falls back to ~/Documents/screenshots, then ~/Desktop/Screenshots.
+ */
+export const defaultOutDir = configuredOutDir;
 
 // SINGLETON — the only Semaphore instance in the entire codebase
 export const puppeteerSemaphore = new Semaphore(MAX_CONCURRENT_SCREENSHOTS);

--- a/src/config/runtime.ts
+++ b/src/config/runtime.ts
@@ -5,7 +5,7 @@ import { mkdirSync } from 'fs';
 import { join } from 'path';
 
 export { homeDir };
-export const defaultOutDir = join(homeDir, 'Desktop', 'Screenshots');
+export const defaultOutDir = join(homeDir, 'Documents', 'screenshots');
 
 // SINGLETON — the only Semaphore instance in the entire codebase
 export const puppeteerSemaphore = new Semaphore(MAX_CONCURRENT_SCREENSHOTS);


### PR DESCRIPTION
Make the default screenshot output directory configurable via the `SCREENSHOT_OUTPUT_DIR` environment variable.

## Changes
- Added `SCREENSHOT_OUTPUT_DIR` env var support for dynamic output directory configuration
- Configurable default output directory with fallback chain:
  1. `SCREENSHOT_OUTPUT_DIR` env var (user-configured)
  2. `~/Documents/screenshots` (new default)
  3. `~/Desktop/Screenshots` (original default)
- Dynamically adds configured directory to `ALLOWED_OUTPUT_DIRS` for path validation

## Usage
Set the environment variable when starting the MCP server:
```json
{
  "mcpServers": {
    "screenshot": {
      "command": "npx",
      "args": ["-y", "universal-screenshot-mcp"],
      "env": {
        "SCREENSHOT_OUTPUT_DIR": "Documents/screenshots"
      }
    }
  }
}
```