### PR TITLE
fix(windows): DPI awareness for high-DPI displays and multi-monitor virtual screen capture

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "universal-screenshot-mcp",
-  "version": "1.0.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "universal-screenshot-mcp",
-      "version": "1.0.0",
+      "version": "1.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",
@@ -1279,7 +1279,6 @@
       "version": "8.54.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -1601,7 +1600,6 @@
       "version": "8.15.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2085,8 +2083,7 @@
     },
     "node_modules/devtools-protocol": {
       "version": "0.0.1551306",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -2250,7 +2247,6 @@
       "version": "9.39.2",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2514,7 +2510,6 @@
     "node_modules/express": {
       "version": "5.2.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -2865,7 +2860,6 @@
     "node_modules/hono": {
       "version": "4.11.7",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -3464,7 +3458,6 @@
       "version": "4.0.3",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4095,7 +4088,6 @@
       "version": "5.7.2",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4135,7 +4127,6 @@
       "version": "7.3.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -4209,7 +4200,6 @@
       "version": "4.0.18",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",
@@ -4412,7 +4402,6 @@
     "node_modules/zod": {
       "version": "3.25.76",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/utils/windows-provider.ts
+++ b/src/utils/windows-provider.ts
@@ -19,9 +19,11 @@ using System.Runtime.InteropServices;
 public class DpiAwareness {
     [DllImport("user32.dll")]
     public static extern bool SetProcessDPIAware();
+    [DllImport("user32.dll", SetLastError = true)]
+    public static extern bool SetProcessDpiAwarenessContext(IntPtr value);
 }
 "@
-[DpiAwareness]::SetProcessDPIAware() | Out-Null`.trim();
+try { [DpiAwareness]::SetProcessDpiAwarenessContext([IntPtr]::new(-4)) | Out-Null } catch { [DpiAwareness]::SetProcessDPIAware() | Out-Null }`.trim();
 
   async isAvailable(): Promise<boolean> {
     return commandExists('powershell');
@@ -31,15 +33,25 @@ public class DpiAwareness {
     if (opts.delay && opts.delay > 0) await sleep(opts.delay);
 
     const format = this.dotNetFormat(opts.format);
-    const displayIndex = (opts.display ?? 1) - 1; // Convert 1-based to 0-based
+
+    // No display specified → capture entire virtual screen (all monitors combined)
+    // display specified → capture that specific monitor
+    const captureAllDisplays = opts.display === undefined || opts.display === null;
+    const displayIndex = captureAllDisplays ? 0 : (opts.display! - 1);
+
+    const boundsScript = captureAllDisplays
+      ? `
+$bounds = [System.Windows.Forms.SystemInformation]::VirtualScreen`
+      : `
+$screens = [System.Windows.Forms.Screen]::AllScreens
+$screen = if (${displayIndex} -lt $screens.Length) { $screens[${displayIndex}] } else { [System.Windows.Forms.Screen]::PrimaryScreen }
+$bounds = $screen.Bounds`;
 
     const script = `
 ${WindowsProvider.DPI_AWARE_SNIPPET}
 Add-Type -AssemblyName System.Windows.Forms
 Add-Type -AssemblyName System.Drawing
-$screens = [System.Windows.Forms.Screen]::AllScreens
-$screen = if (${displayIndex} -lt $screens.Length) { $screens[${displayIndex}] } else { [System.Windows.Forms.Screen]::PrimaryScreen }
-$bounds = $screen.Bounds
+${boundsScript}
 $bitmap = New-Object System.Drawing.Bitmap($bounds.Width, $bounds.Height)
 $graphics = [System.Drawing.Graphics]::FromImage($bitmap)
 ${opts.includeCursor ? '$cursorPos = [System.Windows.Forms.Cursor]::Position\n' : ''}


### PR DESCRIPTION
## Summary

- **Fix Windows high-DPI screenshot cropping**: On Windows 10/11 with display scaling (e.g. 125%, 150%, 200%), screenshots captured via PowerShell's `CopyFromScreen` were cropped on the right and bottom edges. This was because the PowerShell process was not DPI-aware, causing `Screen.Bounds` and `GetWindowRect` to return scaled (logical) coordinates while `CopyFromScreen` operates on physical pixels.
  - Added `SetProcessDpiAwarenessContext(-4)` (PER_MONITOR_AWARE_V2) before any screen/window measurement, with a fallback to `SetProcessDPIAware()` for older Windows versions (pre-1607).
- **Add multi-monitor combined capture**: When `display` parameter is not specified in fullscreen mode, capture the entire virtual desktop (all monitors combined) using `SystemInformation.VirtualScreen` instead of only capturing the primary monitor. When a specific `display` number is provided (1, 2, etc.), the behavior remains unchanged — only that monitor is captured.

## Environment

- **OS**: Windows 10 22H2 (Build 26200), dual-monitor setup
- **Display scaling**: 125% on both monitors
- **Node.js**: v22.x
- **PowerShell**: 5.1

## Test Scenarios Verified

All tests performed on Windows 10 with 125% DPI scaling and dual monitors:

| Scenario | Result |
|----------|--------|
| `mode: "window"`, `windowName: "Cursor"` | Full window captured, no cropping |
| `mode: "window"`, `windowName: "Relay"` | Full window captured, no cropping |
| `mode: "window"`, `windowName: "Edge"` | Full window captured, no cropping |
| `mode: "fullscreen"`, `display: 1` | Monitor 1 fully captured |
| `mode: "fullscreen"`, `display: 2` | Monitor 2 fully captured |
| `mode: "fullscreen"` (no display param) | Both monitors combined into one screenshot (new behavior) |
| `mode: "region"` | Region captured at correct coordinates |

## Technical Details

### DPI Fix

The `DPI_AWARE_SNIPPET` now declares and calls `SetProcessDpiAwarenessContext` with value `-4` (PER_MONITOR_AWARE_V2). This is the highest level of DPI awareness available on Windows, ensuring all Win32 APIs return physical pixel coordinates. The `try/catch` block falls back to `SetProcessDPIAware()` for Windows versions that don't support the newer API.

```csharp
// Added to DPI_AWARE_SNIPPET
[DllImport("user32.dll", SetLastError = true)]
public static extern bool SetProcessDpiAwarenessContext(IntPtr value);

// Called with fallback
try { SetProcessDpiAwarenessContext(-4) } catch { SetProcessDPIAware() }
```

### Multi-Monitor Virtual Screen

When no `display` is specified, the capture bounds come from `SystemInformation.VirtualScreen` which encompasses all monitors. This returns a `Rectangle` with potentially negative `X`/`Y` values (for monitors positioned to the left/above the primary). `CopyFromScreen` handles these coordinates correctly.

## Backward Compatibility

- **macOS/Linux**: No changes — `windows-provider.ts` is only loaded on Windows (`process.platform === 'win32'`).
- **Windows with specific `display` param**: Behavior unchanged — captures only the specified monitor.
- **Windows without `display` param**: Previous behavior captured only the primary monitor; new behavior captures all monitors combined. This is arguably the more expected default for "fullscreen".
- **Older Windows versions**: `SetProcessDpiAwarenessContext` is wrapped in try/catch, falling back to `SetProcessDPIAware()` which has been available since Windows Vista.
