### PR TITLE
fix(windows): DPI awareness, PowerShell path fallback, cross-platform homedir, and Unicode window name support

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -24,7 +24,7 @@ export const ALLOW_LOCAL: boolean = process.env.ALLOW_LOCAL === 'true';
  * Only these directories (and their subdirectories) are permitted for file output.
  * os.homedir() works cross-platform (USERPROFILE on Windows, HOME on Unix).
  */
-export const homeDir = process.env.HOME || homedir() || '/tmp';
+export const homeDir = process.env.HOME || homedir();
 
 /**
  * Resolved default output directory for screenshots.

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -3,6 +3,7 @@
 // ============================================================================
 
 import { join } from 'path';
+import { homedir, tmpdir } from 'os';
 
 /**
  * Maximum number of concurrent Puppeteer browser instances.
@@ -21,9 +22,9 @@ export const ALLOW_LOCAL: boolean = process.env.ALLOW_LOCAL === 'true';
 /**
  * Resolved allowed output directories for screenshots.
  * Only these directories (and their subdirectories) are permitted for file output.
- * Uses process.env.HOME at module load time (pure computation, no I/O side effects).
+ * os.homedir() works cross-platform (USERPROFILE on Windows, HOME on Unix).
  */
-export const homeDir = process.env.HOME || '/tmp';
+export const homeDir = process.env.HOME || homedir() || '/tmp';
 
 /**
  * Resolved default output directory for screenshots.
@@ -36,7 +37,7 @@ export const configuredOutDir = process.env.SCREENSHOT_OUTPUT_DIR
 export const ALLOWED_OUTPUT_DIRS: readonly string[] = [
   join(homeDir, 'Desktop', 'Screenshots'), // ~/Desktop/Screenshots (original default)
   configuredOutDir,                         // Configured default output directory
-  '/tmp',                                   // System temp directory
+  tmpdir(),                                  // System temp directory (cross-platform)
   join(homeDir, 'Downloads'),               // ~/Downloads
   join(homeDir, 'Documents'),               // ~/Documents
 ];

--- a/src/utils/windows-provider.ts
+++ b/src/utils/windows-provider.ts
@@ -19,9 +19,11 @@ using System.Runtime.InteropServices;
 public class DpiAwareness {
     [DllImport("user32.dll")]
     public static extern bool SetProcessDPIAware();
+    [DllImport("user32.dll", SetLastError = true)]
+    public static extern bool SetProcessDpiAwarenessContext(IntPtr value);
 }
 "@
-[DpiAwareness]::SetProcessDPIAware() | Out-Null`.trim();
+try { [DpiAwareness]::SetProcessDpiAwarenessContext([IntPtr]::new(-4)) | Out-Null } catch { [DpiAwareness]::SetProcessDPIAware() | Out-Null }`.trim();
 
   async isAvailable(): Promise<boolean> {
     return commandExists('powershell');
@@ -31,15 +33,25 @@ public class DpiAwareness {
     if (opts.delay && opts.delay > 0) await sleep(opts.delay);
 
     const format = this.dotNetFormat(opts.format);
-    const displayIndex = (opts.display ?? 1) - 1; // Convert 1-based to 0-based
+
+    // No display specified → capture entire virtual screen (all monitors combined)
+    // display specified → capture that specific monitor
+    const captureAllDisplays = opts.display === undefined || opts.display === null;
+    const displayIndex = captureAllDisplays ? 0 : (opts.display! - 1);
+
+    const boundsScript = captureAllDisplays
+      ? `
+$bounds = [System.Windows.Forms.SystemInformation]::VirtualScreen`
+      : `
+$screens = [System.Windows.Forms.Screen]::AllScreens
+$screen = if (${displayIndex} -lt $screens.Length) { $screens[${displayIndex}] } else { [System.Windows.Forms.Screen]::PrimaryScreen }
+$bounds = $screen.Bounds`;
 
     const script = `
 ${WindowsProvider.DPI_AWARE_SNIPPET}
 Add-Type -AssemblyName System.Windows.Forms
 Add-Type -AssemblyName System.Drawing
-$screens = [System.Windows.Forms.Screen]::AllScreens
-$screen = if (${displayIndex} -lt $screens.Length) { $screens[${displayIndex}] } else { [System.Windows.Forms.Screen]::PrimaryScreen }
-$bounds = $screen.Bounds
+${boundsScript}
 $bitmap = New-Object System.Drawing.Bitmap($bounds.Width, $bounds.Height)
 $graphics = [System.Drawing.Graphics]::FromImage($bitmap)
 ${opts.includeCursor ? '$cursorPos = [System.Windows.Forms.Cursor]::Position\n' : ''}

--- a/src/utils/windows-provider.ts
+++ b/src/utils/windows-provider.ts
@@ -160,11 +160,12 @@ $bitmap.Dispose()
 
   private async runPowerShell(script: string): Promise<void> {
     const cmd = this.powershellPath ?? 'powershell';
+    const encoded = Buffer.from(script, 'utf16le').toString('base64');
     await execFileAsync(cmd, [
       '-ExecutionPolicy', 'Bypass',
       '-NoProfile',
       '-NonInteractive',
-      '-Command', script,
+      '-EncodedCommand', encoded,
     ]);
   }
 

--- a/src/utils/windows-provider.ts
+++ b/src/utils/windows-provider.ts
@@ -5,12 +5,29 @@
 import type { ScreenshotProvider, CaptureOptions, WindowTarget, RegionTarget } from './screenshot-provider.js';
 import { execFileAsync, commandExists, sleep } from './screenshot-provider.js';
 
+const POWERSHELL_FALLBACK_PATHS = [
+  'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe',
+  'C:\\Windows\\SysWOW64\\WindowsPowerShell\\v1.0\\powershell.exe',
+];
+
+async function resolvePowerShell(): Promise<string | null> {
+  if (await commandExists('powershell')) return 'powershell';
+  for (const p of POWERSHELL_FALLBACK_PATHS) {
+    try {
+      await execFileAsync(p, ['-Command', 'echo ok']);
+      return p;
+    } catch { /* try next */ }
+  }
+  return null;
+}
+
 /**
  * Windows screenshot provider using PowerShell with .NET System.Drawing.
  * Zero external dependencies — PowerShell and .NET are built into all modern Windows.
  */
 export class WindowsProvider implements ScreenshotProvider {
   readonly platform = 'Windows';
+  private powershellPath: string | null = null;
 
   private static readonly DPI_AWARE_SNIPPET = `
 Add-Type -TypeDefinition @"
@@ -26,7 +43,8 @@ public class DpiAwareness {
 try { [DpiAwareness]::SetProcessDpiAwarenessContext([IntPtr]::new(-4)) | Out-Null } catch { [DpiAwareness]::SetProcessDPIAware() | Out-Null }`.trim();
 
   async isAvailable(): Promise<boolean> {
-    return commandExists('powershell');
+    this.powershellPath = await resolvePowerShell();
+    return this.powershellPath !== null;
   }
 
   async captureFullscreen(opts: CaptureOptions): Promise<void> {
@@ -141,7 +159,8 @@ $bitmap.Dispose()
   // ── Private helpers ────────────────────────────────────────────────────
 
   private async runPowerShell(script: string): Promise<void> {
-    await execFileAsync('powershell', [
+    const cmd = this.powershellPath ?? 'powershell';
+    await execFileAsync(cmd, [
       '-ExecutionPolicy', 'Bypass',
       '-NoProfile',
       '-NonInteractive',

--- a/tests/architecture/singleton.test.ts
+++ b/tests/architecture/singleton.test.ts
@@ -30,6 +30,6 @@ describe('Singleton Architecture', () => {
     }
 
     expect(instantiations).toHaveLength(1);
-    expect(instantiations[0]).toContain('config/runtime.ts');
+    expect(instantiations[0].replace(/\\/g, '/')).toContain('config/runtime.ts');
   });
 });

--- a/tests/utils/windows-provider.test.ts
+++ b/tests/utils/windows-provider.test.ts
@@ -17,6 +17,14 @@ import { execFileAsync, sleep } from '../../src/utils/screenshot-provider.js';
 const mockExecFile = vi.mocked(execFileAsync);
 const mockSleep = vi.mocked(sleep);
 
+// PowerShell scripts are now passed via -EncodedCommand (base64 UTF-16LE) so
+// that Unicode arguments survive the ANSI codepage on non-English Windows.
+function decodeScript(callIndex = 0): string {
+  const args = mockExecFile.mock.calls[callIndex][1] as string[];
+  const encoded = args[args.length - 1];
+  return Buffer.from(encoded, 'base64').toString('utf16le');
+}
+
 describe('WindowsProvider', () => {
   let provider: WindowsProvider;
 
@@ -32,8 +40,7 @@ describe('WindowsProvider', () => {
   describe('captureFullscreen', () => {
     it('includes DPI awareness snippet', async () => {
       await provider.captureFullscreen({ outputPath: 'C:\\test.png' });
-      const script = mockExecFile.mock.calls[0][1].slice(-1)[0];
-      expect(script).toContain('SetProcessDPIAware');
+      expect(decodeScript()).toContain('SetProcessDPIAware');
     });
 
     it('calls powershell with CopyFromScreen script', async () => {
@@ -45,24 +52,21 @@ describe('WindowsProvider', () => {
           '-ExecutionPolicy', 'Bypass',
           '-NoProfile',
           '-NonInteractive',
-          '-Command',
-          expect.stringContaining('CopyFromScreen'),
+          '-EncodedCommand',
+          expect.any(String),
         ])
       );
+      expect(decodeScript()).toContain('CopyFromScreen');
     });
 
     it('includes Png format by default', async () => {
       await provider.captureFullscreen({ outputPath: 'C:\\test.png' });
-
-      const script = mockExecFile.mock.calls[0][1].slice(-1)[0];
-      expect(script).toContain('ImageFormat]::Png');
+      expect(decodeScript()).toContain('ImageFormat]::Png');
     });
 
     it('uses Jpeg format when jpg is specified', async () => {
       await provider.captureFullscreen({ outputPath: 'C:\\test.jpg', format: 'jpg' });
-
-      const script = mockExecFile.mock.calls[0][1].slice(-1)[0];
-      expect(script).toContain('ImageFormat]::Jpeg');
+      expect(decodeScript()).toContain('ImageFormat]::Jpeg');
     });
 
     it('sleeps when delay is specified', async () => {
@@ -70,37 +74,50 @@ describe('WindowsProvider', () => {
       expect(mockSleep).toHaveBeenCalledWith(3);
     });
 
-    it('handles display selection', async () => {
+    it('captures the entire virtual desktop when no display is specified', async () => {
+      await provider.captureFullscreen({ outputPath: 'C:\\test.png' });
+
+      const script = decodeScript();
+      expect(script).toContain('SystemInformation]::VirtualScreen');
+      expect(script).not.toContain('AllScreens');
+    });
+
+    it('selects a specific monitor when display is specified', async () => {
       await provider.captureFullscreen({ outputPath: 'C:\\test.png', display: 2 });
 
-      const script = mockExecFile.mock.calls[0][1].slice(-1)[0];
-      // Display 2 = index 1 (0-based)
-      expect(script).toContain('1');
+      const script = decodeScript();
+      // Display 2 → index 1 (0-based) into AllScreens
       expect(script).toContain('AllScreens');
+      expect(script).toContain('$screens[1]');
+      expect(script).not.toContain('VirtualScreen');
     });
   });
 
   describe('captureWindow', () => {
     it('includes DPI awareness snippet', async () => {
       await provider.captureWindow({ outputPath: 'C:\\test.png', windowName: 'Notepad' });
-      const script = mockExecFile.mock.calls[0][1].slice(-1)[0];
-      expect(script).toContain('SetProcessDPIAware');
+      expect(decodeScript()).toContain('SetProcessDPIAware');
     });
 
     it('searches for window by name using Get-Process', async () => {
       await provider.captureWindow({ outputPath: 'C:\\test.png', windowName: 'Notepad' });
 
-      const script = mockExecFile.mock.calls[0][1].slice(-1)[0];
+      const script = decodeScript();
       expect(script).toContain('Get-Process');
       expect(script).toContain('Notepad');
       expect(script).toContain('GetWindowRect');
     });
 
+    it('preserves Unicode (CJK) characters in windowName end-to-end', async () => {
+      await provider.captureWindow({ outputPath: 'C:\\test.png', windowName: '微信' });
+      // -EncodedCommand uses base64 UTF-16LE so non-ASCII window names survive
+      // the ANSI codepage on non-English Windows (the bug this PR fixes).
+      expect(decodeScript()).toContain('微信');
+    });
+
     it('uses windowId as HWND when provided', async () => {
       await provider.captureWindow({ outputPath: 'C:\\test.png', windowId: 12345 });
-
-      const script = mockExecFile.mock.calls[0][1].slice(-1)[0];
-      expect(script).toContain('[IntPtr]::new(12345)');
+      expect(decodeScript()).toContain('[IntPtr]::new(12345)');
     });
 
     it('throws when no windowName or windowId provided', async () => {
@@ -116,8 +133,7 @@ describe('WindowsProvider', () => {
         outputPath: 'C:\\test.png',
         x: 0, y: 0, width: 100, height: 100,
       });
-      const script = mockExecFile.mock.calls[0][1].slice(-1)[0];
-      expect(script).toContain('SetProcessDPIAware');
+      expect(decodeScript()).toContain('SetProcessDPIAware');
     });
 
     it('calls powershell with region coordinates', async () => {
@@ -126,7 +142,7 @@ describe('WindowsProvider', () => {
         x: 100, y: 200, width: 800, height: 600,
       });
 
-      const script = mockExecFile.mock.calls[0][1].slice(-1)[0];
+      const script = decodeScript();
       expect(script).toContain('800');
       expect(script).toContain('600');
       expect(script).toContain('100');
@@ -138,9 +154,7 @@ describe('WindowsProvider', () => {
   describe('path escaping', () => {
     it('escapes single quotes in output path', async () => {
       await provider.captureFullscreen({ outputPath: "C:\\Users\\it's a test\\screenshot.png" });
-
-      const script = mockExecFile.mock.calls[0][1].slice(-1)[0];
-      expect(script).toContain("it''s a test");
+      expect(decodeScript()).toContain("it''s a test");
     });
   });
 });


### PR DESCRIPTION
## Summary

Comprehensive Windows fixes for the PowerShell-based screenshot provider, addressing 4 issues discovered while running the MCP server in ACP (Agent Client Protocol) mode and on Windows 11.

### 1. DPI Awareness for High-DPI Displays & Multi-Monitor Combined Capture
- On Windows 10/11 with display scaling (e.g. 125%, 150%), screenshots were cropped on the right and bottom edges because the PowerShell process was not DPI-aware.
- Added `SetProcessDpiAwarenessContext(-4)` (PER_MONITOR_AWARE_V2) with fallback to `SetProcessDPIAware()` for older Windows.
- When `display` parameter is not specified, capture the entire virtual desktop (all monitors combined) using `SystemInformation.VirtualScreen`.

### 2. PowerShell Path Fallback for ACP/Subprocess Mode
- When the MCP server runs as a subprocess (e.g. via ACP protocol), the child process may inherit a stripped `PATH` that doesn't include `System32\WindowsPowerShell`. This causes `commandExists('powershell')` to fail with "No screenshot tools found for Windows".
- Added fallback probing of common absolute paths (`C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe` and `SysWOW64` variant) when `where powershell` fails.
- The resolved path is cached on the provider instance for reuse.

### 3. Cross-Platform Home Directory Resolution
- `homeDir` was computed as `process.env.HOME || '/tmp'`. On Windows, `HOME` is typically undefined, so screenshots were saved to `C:\tmp\Documents\screenshots\` instead of the user's profile directory.
- Changed to `process.env.HOME || os.homedir() || '/tmp'` — `os.homedir()` correctly resolves `USERPROFILE` on Windows.
- Replaced hardcoded `'/tmp'` in `ALLOWED_OUTPUT_DIRS` with `os.tmpdir()` for cross-platform compatibility.

### 4. Unicode Window Name Support via `-EncodedCommand`
- Chinese/CJK characters in `windowName` (e.g. "微信", "设置") were garbled when passed via `-Command` parameter due to ANSI codepage (GBK) conversion on Chinese Windows systems.
- Switched from `-Command <script>` to `-EncodedCommand <base64>` which accepts Base64-encoded UTF-16LE, preserving all Unicode characters correctly.

> Co-authored with [Cursor IDE](https://cursor.com) + Claude Opus 4.6.

## Environment

- **OS**: Windows 11 (Build 26200), dual-monitor setup
- **Display scaling**: 125% on both monitors
- **Node.js**: v22.x
- **PowerShell**: 5.1
- **Test mode**: Both direct Cursor IDE MCP and ACP subprocess mode

## Test Scenarios Verified

All tests performed on Windows 11 with 125% DPI scaling and dual monitors:

### DPI & Multi-Monitor Tests

| Scenario | Result |
|----------|--------|
| `mode: "window"`, `windowName: "Cursor"` | ✅ Full window captured, no cropping |
| `mode: "window"`, `windowName: "Relay"` | ✅ Full window captured, no cropping |
| `mode: "window"`, `windowName: "Edge"` | ✅ Full window captured, no cropping |
| `mode: "fullscreen"`, `display: 1` | ✅ Monitor 1 fully captured |
| `mode: "fullscreen"`, `display: 2` | ✅ Monitor 2 fully captured |
| `mode: "fullscreen"` (no display param) | ✅ Both monitors combined into one screenshot |
| `mode: "region"` | ✅ Region captured at correct coordinates |

### PowerShell Fallback Test (ACP Mode)

| Scenario | Before | After |
|----------|--------|-------|
| MCP launched via ACP subprocess (stripped PATH) | ❌ "No screenshot tools found for Windows" | ✅ Found PowerShell via absolute path fallback |

### Home Directory Path Test

| Scenario | Before | After |
|----------|--------|-------|
| Screenshot save path on Windows | ❌ `C:\tmp\Documents\screenshots\` | ✅ `C:\Users\<user>\Documents\screenshots\` |

### Unicode Window Name Test

| Scenario | Before | After |
|----------|--------|-------|
| `windowName: "微信"` (Chinese: WeChat) | ❌ Garbled `Window not found: ????` | ✅ Window found and captured |
| `windowName: "设置"` (Chinese: Settings) | ❌ Garbled | ✅ Window found and captured |
| `windowName: "Cursor"` (ASCII) | ✅ | ✅ (no regression) |

## Technical Details

### DPI Fix
The `DPI_AWARE_SNIPPET` calls `SetProcessDpiAwarenessContext(-4)` (PER_MONITOR_AWARE_V2) to ensure all Win32 APIs return physical pixel coordinates.

### PowerShell Fallback
```typescript
const POWERSHELL_FALLBACK_PATHS = [
  'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe',
  'C:\\Windows\\SysWOW64\\WindowsPowerShell\\v1.0\\powershell.exe',
];
```

### Unicode Encoding
```typescript
// Before: characters garbled by ANSI codepage conversion
await execFileAsync(cmd, ['-Command', script]);

// After: UTF-16LE preserved via Base64 encoding
const encoded = Buffer.from(script, 'utf16le').toString('base64');
await execFileAsync(cmd, ['-EncodedCommand', encoded]);
```

## Backward Compatibility

- **macOS/Linux**: No changes — `windows-provider.ts` is only loaded on Windows.
- **Windows with `display` param**: Behavior unchanged — captures specified monitor.
- **Windows without `display` param**: Now captures all monitors combined (more intuitive default).
- **ASCII window names**: No regression — `-EncodedCommand` handles ASCII identically.
- **PowerShell on PATH**: `resolvePowerShell()` checks PATH first; fallback only activates when PATH lookup fails.
