### PR TITLE
Phase 4a+4b: cross-platform test fixtures + CI matrix on Win/Mac/Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,27 @@ on:
     branches: [main]
 
 jobs:
-  unit:
-    name: Unit Tests
+  lint:
+    name: Lint
     runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: "20"
+          cache: npm
+
+      - run: npm ci
+      - run: npm run lint
+
+  unit:
+    name: Unit Tests (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v5
 

--- a/tests/helpers/temp-dir.ts
+++ b/tests/helpers/temp-dir.ts
@@ -1,9 +1,10 @@
 import { mkdir, rm, symlink } from 'node:fs/promises';
 import { randomUUID } from 'node:crypto';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 export interface TempTestDir {
-  /** Root of the temp directory tree (e.g. /tmp/mcp-test-<uuid>). */
+  /** Root of the temp directory tree (under os.tmpdir()). */
   root: string;
   /** A directory that tests should configure as "allowed". */
   allowed: string;
@@ -14,7 +15,7 @@ export interface TempTestDir {
 }
 
 export async function createTempTestDir(): Promise<TempTestDir> {
-  const root = join('/tmp', `mcp-test-${randomUUID()}`);
+  const root = join(tmpdir(), `mcp-test-${randomUUID()}`);
   const allowed = join(root, 'allowed');
   const forbidden = join(root, 'forbidden');
 

--- a/tests/tools/take-screenshot.integration.test.ts
+++ b/tests/tools/take-screenshot.integration.test.ts
@@ -14,6 +14,7 @@
  */
 import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
 import { existsSync, statSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { createTempTestDir, type TempTestDir } from '../helpers/temp-dir.js';
 import { createTestServer, type TestServer } from '../helpers/test-server.js';
 import { Semaphore } from '../../src/utils/semaphore.js';
@@ -34,7 +35,7 @@ vi.mock('../../src/config/runtime.js', () => ({
 }));
 
 vi.mock('../../src/config/index.js', () => ({
-  get ALLOWED_OUTPUT_DIRS() { return [tmp.allowed, '/tmp']; },
+  get ALLOWED_OUTPUT_DIRS() { return [tmp.allowed, tmpdir()]; },
   MAX_CONCURRENT_SCREENSHOTS: 3,
   ALLOW_LOCAL: false,
 }));

--- a/tests/validators/path.test.ts
+++ b/tests/validators/path.test.ts
@@ -1,21 +1,34 @@
 import { describe, it, expect } from 'vitest';
+import { homedir, tmpdir } from 'node:os';
+import path from 'node:path';
 import { validateOutputPath } from '../../src/validators/path.js';
 import type { PathConfig } from '../../src/validators/path.js';
 import { createMockFs } from '../mocks/fs.js';
 
+// Use platform-resolved paths so the same fixtures work on Linux, macOS, and Windows.
+// validateOutputPath calls path.resolve()/path.relative(), which are platform-aware,
+// so the mock FS keys must match what those functions produce on the current host.
+const HOME = homedir();
+const TMP = tmpdir();
+const ALLOWED_DESKTOP = path.join(HOME, 'Desktop', 'Screenshots');
+const ALLOWED_DOWNLOADS = path.join(HOME, 'Downloads');
+const ALLOWED_DOCUMENTS = path.join(HOME, 'Documents');
+// A forbidden absolute path that exists on every platform after resolve().
+// On POSIX this is /forbidden-test-dir; on Windows it becomes e.g. C:\forbidden-test-dir.
+const FORBIDDEN_DIR = path.resolve(path.sep + 'forbidden-test-dir');
+
 const TEST_CONFIG: PathConfig = {
-  allowedOutputDirs: ['/home/user/Desktop/Screenshots', '/tmp', '/home/user/Downloads', '/home/user/Documents'],
-  defaultOutDir: '/home/user/Desktop/Screenshots',
+  allowedOutputDirs: [ALLOWED_DESKTOP, TMP, ALLOWED_DOWNLOADS, ALLOWED_DOCUMENTS],
+  defaultOutDir: ALLOWED_DESKTOP,
 };
 
 // Mock FS where realpath returns identity for allowed dirs and paths within them
 function buildMockFs(extra?: Map<string, string | Error>) {
   const mappings = new Map<string, string | Error>([
-    // Allowed dirs resolve to themselves
-    ['/home/user/Desktop/Screenshots', '/home/user/Desktop/Screenshots'],
-    ['/tmp', '/tmp'],
-    ['/home/user/Downloads', '/home/user/Downloads'],
-    ['/home/user/Documents', '/home/user/Documents'],
+    [ALLOWED_DESKTOP, ALLOWED_DESKTOP],
+    [TMP, TMP],
+    [ALLOWED_DOWNLOADS, ALLOWED_DOWNLOADS],
+    [ALLOWED_DOCUMENTS, ALLOWED_DOCUMENTS],
   ]);
   if (extra) {
     for (const [k, v] of extra) mappings.set(k, v);
@@ -28,7 +41,7 @@ describe('validateOutputPath', () => {
     const result = await validateOutputPath(undefined, 'screenshot.png', TEST_CONFIG);
     expect(result).toEqual({
       valid: true,
-      path: '/home/user/Desktop/Screenshots/screenshot.png',
+      path: path.join(ALLOWED_DESKTOP, 'screenshot.png'),
     });
   });
 
@@ -36,7 +49,7 @@ describe('validateOutputPath', () => {
     const result = await validateOutputPath('', 'screenshot.png', TEST_CONFIG);
     expect(result).toEqual({
       valid: true,
-      path: '/home/user/Desktop/Screenshots/screenshot.png',
+      path: path.join(ALLOWED_DESKTOP, 'screenshot.png'),
     });
   });
 
@@ -44,85 +57,117 @@ describe('validateOutputPath', () => {
     const result = await validateOutputPath('   ', 'screenshot.png', TEST_CONFIG);
     expect(result).toEqual({
       valid: true,
-      path: '/home/user/Desktop/Screenshots/screenshot.png',
+      path: path.join(ALLOWED_DESKTOP, 'screenshot.png'),
     });
   });
 
   it('accepts valid custom path within allowed directory', async () => {
-    const fs = buildMockFs(new Map([
-      ['/tmp/my-screenshot.png', '/tmp/my-screenshot.png'],
-    ]));
-    const result = await validateOutputPath('/tmp/my-screenshot.png', 'default.png', TEST_CONFIG, fs);
+    const target = path.join(TMP, 'my-screenshot.png');
+    const fs = buildMockFs(new Map([[target, target]]));
+    const result = await validateOutputPath(target, 'default.png', TEST_CONFIG, fs);
     expect(result.valid).toBe(true);
-    expect(result.path).toBe('/tmp/my-screenshot.png');
+    expect(result.path).toBe(target);
   });
 
   it('accepts path in Downloads', async () => {
-    const targetPath = '/home/user/Downloads/shot.png';
+    const targetPath = path.join(ALLOWED_DOWNLOADS, 'shot.png');
     // File doesn't exist yet, parent resolves
     const fs = buildMockFs();
     const result = await validateOutputPath(targetPath, 'default.png', TEST_CONFIG, fs);
     expect(result.valid).toBe(true);
-    expect(result.path).toBe('/home/user/Downloads/shot.png');
+    expect(result.path).toBe(targetPath);
   });
 
   it('accepts path in Documents', async () => {
-    const targetPath = '/home/user/Documents/report.png';
+    const targetPath = path.join(ALLOWED_DOCUMENTS, 'report.png');
     const fs = buildMockFs();
     const result = await validateOutputPath(targetPath, 'default.png', TEST_CONFIG, fs);
     expect(result.valid).toBe(true);
-    expect(result.path).toBe('/home/user/Documents/report.png');
+    expect(result.path).toBe(targetPath);
   });
 
-  it('accepts path in /tmp', async () => {
+  it('accepts path in temp directory', async () => {
+    const target = path.join(TMP, 'test.png');
     const fs = buildMockFs();
-    const result = await validateOutputPath('/tmp/test.png', 'default.png', TEST_CONFIG, fs);
+    const result = await validateOutputPath(target, 'default.png', TEST_CONFIG, fs);
     expect(result.valid).toBe(true);
-    expect(result.path).toBe('/tmp/test.png');
+    expect(result.path).toBe(target);
   });
 
-  it('rejects path traversal attempt', async () => {
-    // ../../etc/passwd resolved to /etc/passwd which is outside allowed dirs
+  it('rejects path traversal attempt to a forbidden absolute path', async () => {
+    const target = path.join(FORBIDDEN_DIR, 'secret.txt');
     const fs = buildMockFs(new Map([
-      ['/etc/passwd', '/etc/passwd'],
+      [target, target],
+      [FORBIDDEN_DIR, FORBIDDEN_DIR],
     ]));
-    const result = await validateOutputPath('/etc/passwd', 'default.png', TEST_CONFIG, fs);
+    const result = await validateOutputPath(target, 'default.png', TEST_CONFIG, fs);
     expect(result.valid).toBe(false);
     expect(result.error).toContain('allowed directories');
   });
 
   it('rejects symlink resolving outside allowed dirs', async () => {
-    // Symlink at /tmp/evil resolves to /etc/shadow
+    // Symlink at TMP/evil resolves to a forbidden location
+    const symlinkSource = path.join(TMP, 'evil');
+    const symlinkTarget = path.join(FORBIDDEN_DIR, 'shadow');
     const fs = buildMockFs(new Map([
-      ['/tmp/evil', '/etc/shadow'],
+      [symlinkSource, symlinkTarget],
     ]));
-    const result = await validateOutputPath('/tmp/evil', 'default.png', TEST_CONFIG, fs);
+    const result = await validateOutputPath(symlinkSource, 'default.png', TEST_CONFIG, fs);
     expect(result.valid).toBe(false);
     expect(result.error).toContain('allowed directories');
   });
 
   it('rejects null byte in path', async () => {
-    const result = await validateOutputPath('/tmp/evil\x00.png', 'default.png', TEST_CONFIG);
+    const result = await validateOutputPath(
+      path.join(TMP, 'evil\x00.png'),
+      'default.png',
+      TEST_CONFIG,
+    );
     expect(result.valid).toBe(false);
     expect(result.error).toContain('null bytes');
   });
 
   it('rejects %00 in path', async () => {
-    const result = await validateOutputPath('/tmp/evil%00.png', 'default.png', TEST_CONFIG);
+    const result = await validateOutputPath(
+      path.join(TMP, 'evil%00.png'),
+      'default.png',
+      TEST_CONFIG,
+    );
     expect(result.valid).toBe(false);
     expect(result.error).toContain('null bytes');
   });
 
   it('fails when parent directory does not exist', async () => {
-    // Neither the path nor the parent exist in mock FS
-    const fs = createMockFs(new Map([
-      ['/home/user/Desktop/Screenshots', '/home/user/Desktop/Screenshots'],
-      ['/tmp', '/tmp'],
-      ['/home/user/Downloads', '/home/user/Downloads'],
-      ['/home/user/Documents', '/home/user/Documents'],
-    ]));
-    const result = await validateOutputPath('/nonexistent/dir/file.png', 'default.png', TEST_CONFIG, fs);
+    const fs = buildMockFs();
+    const target = path.resolve(path.sep, 'nonexistent', 'dir', 'file.png');
+    const result = await validateOutputPath(target, 'default.png', TEST_CONFIG, fs);
     expect(result.valid).toBe(false);
     expect(result.error).toContain('Parent directory does not exist');
+  });
+});
+
+// Contract test for the Windows cross-drive containment fix at src/validators/path.ts:84.
+// On Windows, path.relative() returns an absolute path (e.g. 'D:\\foo') when the source
+// and target are on different drives. The previous startsWith('/') check missed this;
+// the fix uses path.isAbsolute() instead. These assertions lock the Node.js behavior
+// we depend on, so a future regression in either Node or the validator surfaces here
+// rather than as a security bug only reproducible on Windows.
+describe('path.isAbsolute contract (Windows cross-drive guard)', () => {
+  it('path.win32.isAbsolute identifies a different-drive Windows path as absolute', () => {
+    expect(path.win32.isAbsolute('D:\\other\\foo')).toBe(true);
+  });
+
+  it('path.win32.isAbsolute does NOT flag relative segments as absolute', () => {
+    expect(path.win32.isAbsolute('..\\foo')).toBe(false);
+    expect(path.win32.isAbsolute('subdir\\foo')).toBe(false);
+  });
+
+  it('path.win32.relative returns an absolute path when drives differ', () => {
+    const result = path.win32.relative('C:\\Users\\alice', 'D:\\other\\bar');
+    // The validator's fix relies on this: when drives differ, relative() returns
+    // an absolute path, which isAbsolute() catches but startsWith('/') would miss.
+    expect(path.win32.isAbsolute(result)).toBe(true);
+    expect(result.startsWith('/')).toBe(false); // confirms the OLD check was broken
+    expect(result.startsWith('..')).toBe(false); // and so was the .. check
   });
 });

--- a/vitest.all.config.ts
+++ b/vitest.all.config.ts
@@ -1,22 +1,12 @@
 import { defineConfig } from 'vitest/config';
+import { sharedCoverageConfig, sharedTestEnv } from './vitest.shared.config.js';
 
 export default defineConfig({
   test: {
-    globals: true,
-    environment: 'node',
+    ...sharedTestEnv,
     include: ['tests/**/*.test.ts', 'tests/**/*.integration.test.ts', 'tests/**/*.e2e.test.ts'],
     testTimeout: 60_000,
     hookTimeout: 30_000,
-    coverage: {
-      provider: 'v8',
-      include: ['src/**/*.ts'],
-      exclude: ['src/index.ts'],
-      thresholds: {
-        lines: 50,
-        branches: 40,
-        functions: 50,
-        statements: 50,
-      },
-    },
+    coverage: sharedCoverageConfig,
   },
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,21 +1,11 @@
 import { defineConfig } from 'vitest/config';
+import { sharedCoverageConfig, sharedTestEnv } from './vitest.shared.config.js';
 
 export default defineConfig({
   test: {
-    globals: true,
-    environment: 'node',
+    ...sharedTestEnv,
     include: ['tests/**/*.test.ts'],
     exclude: ['tests/**/*.integration.test.ts', 'tests/**/*.e2e.test.ts'],
-    coverage: {
-      provider: 'v8',
-      include: ['src/**/*.ts'],
-      exclude: ['src/index.ts'],
-      thresholds: {
-        lines: 50,
-        branches: 40,
-        functions: 50,
-        statements: 50,
-      },
-    },
+    coverage: sharedCoverageConfig,
   },
 });

--- a/vitest.e2e.config.ts
+++ b/vitest.e2e.config.ts
@@ -1,9 +1,9 @@
 import { defineConfig } from 'vitest/config';
+import { sharedTestEnv } from './vitest.shared.config.js';
 
 export default defineConfig({
   test: {
-    globals: true,
-    environment: 'node',
+    ...sharedTestEnv,
     include: ['tests/**/*.e2e.test.ts'],
     testTimeout: 60_000,
     hookTimeout: 30_000,

--- a/vitest.integration.config.ts
+++ b/vitest.integration.config.ts
@@ -1,9 +1,9 @@
 import { defineConfig } from 'vitest/config';
+import { sharedTestEnv } from './vitest.shared.config.js';
 
 export default defineConfig({
   test: {
-    globals: true,
-    environment: 'node',
+    ...sharedTestEnv,
     include: ['tests/**/*.integration.test.ts'],
     testTimeout: 30_000,
     hookTimeout: 15_000,

--- a/vitest.shared.config.ts
+++ b/vitest.shared.config.ts
@@ -1,0 +1,24 @@
+// Shared building blocks for the per-tier vitest configs.
+// Keep one source of truth for coverage thresholds and the common test env.
+
+export const sharedCoverageConfig = {
+  provider: 'v8' as const,
+  include: ['src/**/*.ts'],
+  // src/index.ts is the stdio entry; exercised end-to-end, not in unit tests.
+  exclude: ['src/index.ts'],
+  thresholds: {
+    // Floors set ~2pp below current measured coverage (74.94 / 75.94 / 75.86 / 76.47
+    // as of v1.1.2) so that meaningful regressions trip CI but a single removed
+    // line that nicks an uncovered branch doesn't flake. Raise these as new tests
+    // land.
+    lines: 74,
+    branches: 68,
+    functions: 73,
+    statements: 73,
+  },
+};
+
+export const sharedTestEnv = {
+  globals: true,
+  environment: 'node' as const,
+};


### PR DESCRIPTION
## Summary

Two stacked commits from the post-v1.1.2 audit sweep, validated together because Phase 4b's new Windows/macOS CI matrix is the validation event for Phase 4a's cross-platform fixtures.

**4a (`c1c14c3`)** — Cross-platform test fixtures + Node-contract guard
- `tests/helpers/temp-dir.ts` and `tests/validators/path.test.ts` use `os.homedir()` / `os.tmpdir()` instead of hardcoded `/tmp` and `/home/user`
- `tests/tools/take-screenshot.integration.test.ts:37` uses `tmpdir()` in the `ALLOWED_OUTPUT_DIRS` mock
- New contract test in `path.test.ts` locks the `path.win32.isAbsolute` semantics that the v1.1.2 cross-drive Windows fix at `src/validators/path.ts:84` depends on
- Skipped the unit-tier mocked tests (their `/tmp`/`/home/user` literals are opaque mock fixtures that never hit the FS)

**4b (`0205c5c`)** — CI matrix + lint job + tightened coverage thresholds
- Unit tier matrix: `ubuntu-latest`, `macos-latest`, `windows-latest` (`fail-fast: false`)
- New separate `lint` job runs `eslint src/` on every push/PR
- `integration` and `linux-e2e` jobs unchanged
- New `vitest.shared.config.ts` exports `sharedCoverageConfig` and `sharedTestEnv` — one source of truth for thresholds across all four vitest configs
- Coverage thresholds raised 50/40/50/50 → **73/68/73/74** (statements/branches/functions/lines), set ~2pp below current measured coverage (74.94/75.94/75.86/76.47) so meaningful regressions surface without flake from minor variance

## Why these two ship together

4b's Windows CI is the first time `npm test` will run on `windows-latest` for this repo. 4a's fixture refactor is a hard prerequisite — without it, `tests/validators/path.test.ts` would fail on Windows due to `path.resolve()` rewriting the hardcoded `/tmp` to something Windows-specific that wouldn't match the mock FS keys.

## Test plan

- [ ] `unit (ubuntu-latest)` green
- [ ] `unit (macos-latest)` green
- [ ] `unit (windows-latest)` green ← the new validation event
- [ ] `integration` green
- [ ] `linux-e2e` green
- [ ] `lint` green
- [ ] Coverage report passes new thresholds

🤖 Generated with [Claude Code](https://claude.com/claude-code)