### PR TITLE
ci: auto-create GitHub Release on tag push

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -6,7 +6,7 @@ on:
 
 permissions:
   id-token: write # Required for OIDC (both npm trusted publishing and MCP Registry)
-  contents: read
+  contents: write # Required for `gh release create`
 
 jobs:
   publish:
@@ -54,3 +54,19 @@ jobs:
 
       - name: Publish server to MCP Registry
         run: ./mcp-publisher publish
+
+      ### Create GitHub Release ###
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/v}
+          awk -v ver="$VERSION" '
+            /^## \[/ { if (in_section) exit; if ($0 ~ "^## \\[" ver "\\]") { in_section=1; next } }
+            in_section { print }
+          ' CHANGELOG.md > release-notes.md
+          gh release create "v${VERSION}" \
+            --title "v${VERSION}" \
+            --notes-file release-notes.md \
+            --verify-tag


### PR DESCRIPTION
## Summary

The publish workflow already publishes to npm and the MCP Registry on a `v*` tag push, but never created a corresponding GitHub Release — v1.0.0 through v1.2.0 all exist as tags with no Release attached.

This PR adds a final step that extracts the matching version section from `CHANGELOG.md` and creates a Release with those notes.

## Implementation notes

- Uses `--notes-file release-notes.md` rather than `--notes "$(...)"` so backticks/dollars/quotes inside CHANGELOG bodies can't break shell quoting.
- Bumps `permissions.contents` from `read` → `write` (required by `gh release create`).
- Awk extractor matches the `## [X.Y.Z]` heading and prints until the next `## [` heading. Verified locally against all five existing version sections.

## Backfill

Past tags (v1.0.0 through v1.2.0) will be backfilled separately via a one-time local loop using the same extractor — they won't pick up the new step retroactively because their tag-push events are already in the past.

## Test plan

- [x] Workflow YAML lints (no syntax errors)
- [x] Verified the awk extractor produces clean per-version output for v1.0.0, v1.1.0, v1.1.1, v1.1.2, v1.2.0
- [ ] First real exercise of the new step will be the next tagged release

🤖 Generated with [Claude Code](https://claude.com/claude-code)