### PR TITLE
chore: ignore TypeScript major bumps in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,10 @@ updates:
       # Zod 4 needs MCP SDK 2.x (Standard Schema). Re-enable when SDK 2.x stable lands.
       - dependency-name: "zod"
         update-types: ["version-update:semver-major"]
+      # TypeScript 7 has no typescript-eslint support yet (peer caps at <6.1.0),
+      # so npm ci fails to resolve. Re-enable when typescript-eslint ships TS7 support.
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: github-actions
     directory: "/"


### PR DESCRIPTION
## Why

Dependabot opened #40 to bump `typescript` 6.0.3 → 7.0.2. All six CI jobs failed at `npm ci` with `ERESOLVE`, before anything could build, lint, or test:

```
npm error Could not resolve dependency:
npm error peer typescript@">=4.8.4 <6.1.0" from @typescript-eslint/eslint-plugin@8.63.0
npm error Found: typescript@7.0.2
```

`@typescript-eslint/eslint-plugin` caps its `typescript` peer at `<6.1.0`, and no published version lifts that cap yet:

| Version | `typescript` peer range |
|---|---|
| `8.65.0` (latest) | `>=4.8.4 <6.1.0` |
| `8.65.1-alpha.2` (canary) | `>=4.8.4 <6.1.0` |

So there is no typescript-eslint upgrade that unblocks the bump. #40 is closed.

## What

Adds a `typescript` major-version ignore rule so Dependabot stops reopening this PR every Monday. Follows the existing pattern already used for `@types/node`, `zod`, and the docker `node` image.

Re-enable once typescript-eslint ships TS 7 support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)