### PR TITLE
chore: drop unused typescript-eslint plugin and pin typescript to ~6.0.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,8 +22,25 @@ updates:
       # SDK 2.x (Standard Schema). Re-enable when SDK 2.x stable lands." SDK 2.x
       # stable has landed and this server is on @modelcontextprotocol/server 2.x
       # with zod 4, so the condition is satisfied and majors flow normally again.
-      # TypeScript 7 has no typescript-eslint support yet (peer caps at <6.1.0),
-      # so npm ci fails to resolve. Re-enable when typescript-eslint ships TS7 support.
+      # TypeScript 7 is the Go-native compiler and ships WITHOUT a programmatic
+      # API, so typescript-eslint cannot support it — its parser hard-throws
+      # "typescript-eslint does not support TS 7.0." at require() time. Note this
+      # is a LINT-TIME failure, not an install-time one: npm only emits ERESOLVE
+      # peer warnings and installs anyway, so CI would go green on install and
+      # then fail in the lint job.
+      #
+      # tsc 7 itself compiles this project cleanly (and ~6x faster), so the
+      # blocker is purely the lint toolchain. There is no typescript-eslint
+      # release that helps — there is no v9, and even the canary still caps its
+      # peer at <6.1.0. Support is tracked against TS >=7.1, which is when
+      # Microsoft plans to ship the new API:
+      #   https://github.com/typescript-eslint/typescript-eslint/issues/10940
+      #
+      # devDependencies.typescript is pinned to ~6.0.0 to make this explicit
+      # rather than implied. Re-evaluate when typescript-eslint ships TS 7.1
+      # support; a side-by-side setup (typescript aliased to
+      # @typescript/typescript6 plus @typescript/native) works today but isn't
+      # worth the complexity at this project's size.
       - dependency-name: "typescript"
         update-types: ["version-update:semver-major"]
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,12 +19,11 @@
       "devDependencies": {
         "@modelcontextprotocol/client": "^2.0.0",
         "@types/node": "^22.0.0",
-        "@typescript-eslint/eslint-plugin": "^8.59.0",
         "@typescript-eslint/parser": "^8.59.0",
         "@vitest/coverage-v8": "^4.0.18",
         "eslint": "^10.2.1",
         "jiti": "^2.4.0",
-        "typescript": "^6.0.0",
+        "typescript": "~6.0.0",
         "vitest": "^4.0.18"
       },
       "engines": {
@@ -763,35 +762,6 @@
         "undici-types": "~6.21.0"
       }
     },
-    "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.65.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.65.0.tgz",
-      "integrity": "sha512-IEgob78X12rHpUmtcwFsXhZdVGJtwTVP8FiCLZkR6GlYVrl2PcuB+KhCE5BlVC/eQpQnu8WXRtkHZuPar+gCRA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.65.0",
-        "@typescript-eslint/type-utils": "8.65.0",
-        "@typescript-eslint/utils": "8.65.0",
-        "@typescript-eslint/visitor-keys": "8.65.0",
-        "ignore": "^7.0.5",
-        "natural-compare": "^1.4.0",
-        "ts-api-utils": "^2.5.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "@typescript-eslint/parser": "^8.65.0",
-        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.1.0"
-      }
-    },
     "node_modules/@typescript-eslint/parser": {
       "version": "8.65.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.65.0.tgz",
@@ -874,31 +844,6 @@
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
-    "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.65.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.65.0.tgz",
-      "integrity": "sha512-YjaZ7PRI5qY7ax2L3PbvX0rRyGtipAReCWs0mhhDBHjH/vl0g0BonaGXrKdKpMbIIsMIwDgbk/xzkBTyAltS5g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/types": "8.65.0",
-        "@typescript-eslint/typescript-estree": "8.65.0",
-        "@typescript-eslint/utils": "8.65.0",
-        "debug": "^4.4.3",
-        "ts-api-utils": "^2.5.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.1.0"
-      }
-    },
     "node_modules/@typescript-eslint/types": {
       "version": "8.65.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.65.0.tgz",
@@ -938,30 +883,6 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <6.1.0"
-      }
-    },
-    "node_modules/@typescript-eslint/utils": {
-      "version": "8.65.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.65.0.tgz",
-      "integrity": "sha512-gXiwIHsYreboxeJucHKPvgwl7dXt50mF8s1/c00cP/WoVTyWKFdtfhRWwZiXYFU5H2O8vVoSLNrexFZjYS/SGA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.65.0",
-        "@typescript-eslint/types": "8.65.0",
-        "@typescript-eslint/typescript-estree": "8.65.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
@@ -1809,16 +1730,6 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/ignore": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
     },
     "node_modules/imurmurhash": {
       "version": "0.1.4",

--- a/package.json
+++ b/package.json
@@ -59,12 +59,11 @@
   "devDependencies": {
     "@modelcontextprotocol/client": "^2.0.0",
     "@types/node": "^22.0.0",
-    "@typescript-eslint/eslint-plugin": "^8.59.0",
     "@typescript-eslint/parser": "^8.59.0",
     "@vitest/coverage-v8": "^4.0.18",
     "eslint": "^10.2.1",
     "jiti": "^2.4.0",
-    "typescript": "^6.0.0",
+    "typescript": "~6.0.0",
     "vitest": "^4.0.18"
   }
 }


### PR DESCRIPTION
Two small cleanups surfaced while investigating the TypeScript 7 upgrade path. No functional change.

## 1. Drop `@typescript-eslint/eslint-plugin`

`eslint.config.js` imports only `@typescript-eslint/parser`. The plugin sat in `devDependencies` but was never referenced by any config, and nothing else in the repo mentions it (no `.eslintrc*`, no `eslintConfig` key in `package.json`).

The parser doesn't depend on it either — its only peers are `eslint` and `typescript`. So removing it leaves linting fully intact.

**Verified it didn't silently disable linting**, which is the failure mode that matters here: after a clean `npm ci` with the plugin gone, a scratch file doing `new Semaphore(3)` still trips the custom rule —

```
2:11  error  Do not instantiate Semaphore directly. Import puppeteerSemaphore
             from config/runtime.ts  no-restricted-syntax
```

## 2. Pin `typescript` from `^6.0.0` to `~6.0.0`

`@typescript-eslint/parser` caps its `typescript` peer at `<6.1.0`. `~6.0.0` expresses exactly that bound, so the real constraint is explicit rather than implied. The previous `^6.0.0` would have accepted a 6.1 minor the parser rejects.

## 3. Correct the TypeScript note in `.github/dependabot.yml`

The old comment claimed "npm ci fails to resolve." That's wrong — npm only emits `ERESOLVE overriding peer dependency` warnings and installs anyway. **The real failure is at lint time**: `@typescript-eslint/parser` hard-throws `typescript-eslint does not support TS 7.0.` at `require()`.

That distinction matters operationally — CI would go green on install and only blow up later in the lint job.

The rewritten comment records what's actually true: TS 7 is the Go-native compiler shipping without a programmatic API; `tsc` 7 compiles this project cleanly (and ~6x faster) so the blocker is purely the lint toolchain; there is no typescript-eslint release that helps (no v9, and even the canary caps at `<6.1.0`); support is tracked against TS >= 7.1 at [typescript-eslint#10940](https://github.com/typescript-eslint/typescript-eslint/issues/10940).

## Verification

- `npm ci` clean — 181 packages, down from 185
- `npm run build`, `npm run lint` both exit 0 after a fresh install
- `npm run test:all` → 234 passed, 8 skipped (the pre-existing `skipIf(!isLinux)` cases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)